### PR TITLE
fix: copy pruned node_modules from build stage to avoid mediasoup pos…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Multi-stage Dockerfile for a Node.js signaling server
 FROM node:24-alpine AS build
 
-# Install build dependencies for mediasoup (Python 3, C++ tools, and kernel headers)
+# Install build dependencies for mediasoup (Python 3, pip, C++ tools, and kernel headers)
 RUN apk add --no-cache \
     python3 \
+    py3-pip \
     make \
     g++ \
     gcc \
@@ -19,10 +20,13 @@ COPY . .
 RUN npm run build
 COPY ./src/protos ./dist/protos
 
+# Prune devDependencies so only production modules are copied to the runtime stage
+RUN npm prune --omit=dev
+
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 FROM node:24-alpine AS runtime
 
-# Keep native build tools so mediasoup bindings load under musl
+# mediasoup native bindings require these libs to load under musl at runtime
 RUN apk add --no-cache \
     python3 \
     make \
@@ -33,10 +37,10 @@ RUN apk add --no-cache \
 
 WORKDIR /usr/src/app
 
-COPY package*.json ./
-RUN npm ci --omit=dev
-
+# Copy already-compiled node_modules (mediasoup worker built in build stage)
+COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
+COPY package*.json ./
 
 EXPOSE 8000
 


### PR DESCRIPTION
…tinstall in runtime

# Pull Request for Mitsi

Thank you for contributing to Mitsi! Please provide the following details to help us review your changes.

## Description

Describe the purpose of this pull request and the changes introduced. What problem does it solve or what feature does it add?

## Related Issues

Link any related issues (e.g., `#123`) or explain if this is a new feature or fix.

## Changes Made

List the key changes made in this pull request (e.g., modified files, new features, bug fixes).

## Testing

Describe how you tested your changes. Did you add or update tests in the `tests` folder?

## Checklist

Please confirm the following by checking the boxes:

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [ ] I have run `npm run lint` locally to ensure code style (source in `src`, tests in `tests`) is correct.
- [ ] I have run `npm run build` locally to verify TypeScript compilation to `dist`.
- [ ] I have run `npm run test` locally to confirm all tests pass.
- [ ] My changes adhere to the MIT License (see [LICENSE](LICENSE)).
- [ ] I have updated documentation (e.g., README, comments) if necessary.

## Additional Notes

Add any other information relevant to this pull request, such as screenshots, performance impacts, or questions for reviewers.

---

**CI Notes**: The CI workflow will automatically run `npm run lint`, `npm run build`, and `npm run test` on this pull request. Ensure these pass locally to avoid CI failures. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
